### PR TITLE
 Use log4j2-logstash-layout without transitive dependencies. We have …

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -162,7 +162,7 @@ object Log4j2 {
 
     object Logstash {
         private const val version = "1.0.2"
-        const val logstashLayout = "com.vlkan.log4j2:log4j2-logstash-layout-fatjar:$version"
+        const val logstashLayout = "com.vlkan.log4j2:log4j2-logstash-layout:$version"
     }
 }
 


### PR DESCRIPTION
…used a fatjar version of log4j2-logstash-layout (https://github.com/vy/log4j2-logstash-layout#fat-jar). The fat jar are bundled with old versions of jackson, log4j2 which may case collision