### PR TITLE
oppdater gradle actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and publish Docker image
     runs-on: ubuntu-latest
     permissions: # Sjekk https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-      contents: "read"
+      contents: "write"
       checks: "write"
       pull-requests: "write"
       id-token: "write"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,15 +22,20 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/wrapper-validation-action@v3.5.0
-      - uses: gradle/gradle-build-action@v3.5.0
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
         env:
           # Eksluder test dependencies
           DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: compileClasspath|runtimeClasspath
         with:
-          gradle-version: wrapper
+          # Generer en krypteringsnøkkel med: openssl rand -base64 16
+          # I repoet på Github: Settings -> Secrets and Variables -> Actions
+          # New repository secret, gi navnet GRADLE_ENCRYPTION_KEY og lim inn
+          # verdien fra kommandoen over, så kan du kommentere inn følgende:
+          # cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           dependency-graph: generate-and-submit
-          arguments: --configuration-cache build installDist
+          arguments: --configuration-cache build
+        run: ./gradlew --configuration-cache build
 
       - name: docker-build-push
         uses: nais/docker-build-push@v0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           # cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           dependency-graph: generate-and-submit
           arguments: --configuration-cache build
-        run: ./gradlew --configuration-cache build
+      - run: ./gradlew --configuration-cache build
 
       - name: docker-build-push
         uses: nais/docker-build-push@v0


### PR DESCRIPTION
https://github.com/gradle/wrapper-validation-action og https://github.com/gradle/gradle-build-action ble arkiverte i februar i år. de nye actionsa ligger i https://github.com/gradle/actions og det er de som benyttes i denne PRen.

i tillegg har jeg lagt inn en instruksjon for å benytte kryptering i cachen til gradle.
grunnlaget for instruksjonen er https://docs.gradle.org/8.6/userguide/configuration_cache.html#config_cache:secrets
