### PR TITLE
chore(deps): bump dp-version-catalog to 20260728.277

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20251205.234.05353f")
+            from("no.nav.dagpenger:dp-version-catalog:20260728.277")
         }
     }
 }


### PR DESCRIPTION
Oppgraderer `dp-version-catalog` fra gammelt til nytt versjonsformat (eldste versjon i nytt format, for å minimere risiko). Ingen andre kodeendringer. `./gradlew test` kjørt lokalt og passerer.